### PR TITLE
Updated API for Bulbs & Warm White (WW)

### DIFF
--- a/lib/ledenet/api.rb
+++ b/lib/ledenet/api.rb
@@ -33,24 +33,24 @@ module LEDENET
       end
     end
 
+    def update_color(r,g,b) # Supports legacy color Updates
+      update_ufo(r,g,b,0,false)
+      true
+    end
 
-
-    def update_ufo(r,g,b,w,persist)
+    def update_ufo(r,g,b,w,persist) # Update a UFO wireless device
       msg = Array.new
       if persist
         msg << 0x31
       else
         msg << 0x41 << r << g << b << w << 0x00 << 0x0f
       end
-     
       checksum = calc_checksum(msg)
-          
       send_bytes_action(*msg, checksum)
-
       true
     end
 
-    def update_bulb_color(r, g, b, persist)
+    def update_bulb_color(r, g, b, persist) # Update a Bulb wireless device's color
       msg = Array.new
       if persist
         msg << 0x31
@@ -59,11 +59,10 @@ module LEDENET
       end
       checksum = calc_checksum(msg)
       send_bytes_action(*msg, checksum)
-
       true
     end
 
-    def update_bulb_white(w, persist)
+    def update_bulb_white(w, persist) # Update a Bulb wireless device's WW level
     msg = Array.new
     if persist
         msg << 0x31
@@ -72,26 +71,19 @@ module LEDENET
       end
         checksum = calc_checksum(msg)
         send_bytes_action(*msg, checksum)
-
         true
     end
 
-    def current_status
-      # Gets bytes 6-9 and returns them as Integers from 0-255 (Red,Green,Blue, and WW)
+    def current_status # Gets bytes 6-9 and returns them as Integers from 0-255 (Red,Green,Blue, and WW) and return power status as string
       current_packet = Array.new
       current_packet = status
       power_state = "off"
       power_state = "on" if current_packet[2].unpack('C').to_s.delete('[]') == "35"
       return Integer(current_packet[6].unpack('C').to_s.delete('[]')).to_i,Integer(current_packet[7].unpack('C').to_s.delete('[]')).to_i,Integer(current_packet[8].unpack('C').to_s.delete('[]')).to_i,Integer(current_packet[9].unpack('C').to_s.delete('[]')).to_i, power_state
-      # Returns RGBW and Power "On" or "Off"
     end
 
     def reconnect!
       create_socket
-    end
-
-    def getStatus # Function to get status only
-      status
     end
 
     def getInfo

--- a/lib/ledenet/api.rb
+++ b/lib/ledenet/api.rb
@@ -82,6 +82,13 @@ module LEDENET
       return Integer(current_packet[6].unpack('C').to_s.delete('[]')).to_i,Integer(current_packet[7].unpack('C').to_s.delete('[]')).to_i,Integer(current_packet[8].unpack('C').to_s.delete('[]')).to_i,Integer(current_packet[9].unpack('C').to_s.delete('[]')).to_i, power_state
     end
 
+    def current_color
+      current_packet = Array.new
+      current_packet = status
+      currentColors = Array.new
+      currentColors << Integer(current_packet[6].unpack('C').to_s.delete('[]')).to_i << Integer(current_packet[7].unpack('C').to_s.delete('[]')).to_i << Integer(current_packet[8].unpack('C').to_s.delete('[]')).to_i
+    end
+    
     def reconnect!
       create_socket
     end


### PR DESCRIPTION
### This PR has the following changes:
- _[Fixed]_ The previous method for on? checked byte [13] to test if a device was on. The on/off state is actually carried in byte [3], and [13] is the checksum.
- _[Changed]_ update_color() now passes through to the update_ufo() method with the same variables for legacy protection.
- _[Added]_ update_bulb_color(). This method enables color mode on a bulb and changes the color.
- _[Added]_ update_bulb_white(). This method enables white mode on a bulb and adjusts the level.
- _[Added]_ current_status(). This method gets the current status of the light in R,G,B,W, and "on" or "off"
- *[Changed] current_color() uses a different method to get the status of colors for legacy requests.
- *[Added] get_info(). This method was used for debugging and returns an array of all 14 of a device's bytes.
- _[Changed]_ calc_checksum(). This method parses an entire input array of bytes to give a correct checksum for use with WW devices. Previously, the method only added RGB with other static variables to build the checksum.
- _[Changed]_ def_status(). Removed comment with some deprecated info in it.
### Bugs:
- _[No known bugs. Please report if there are any.]_
### To-do:
- _[Add]_ Fade modes from app. I've managed to get the presets figured out, but am still working out how to send preset fade modes.
- _[Add]_ Date and time-setting.(I'm not sure how useful this is with SmartThings, etc... but I will add it if requested.)
- _[Add]_ Timer functionality. (I'm not sure how useful this is with SmartThings, etc... but I will add it if requested.)
- _[Add]_ RGB-only devices (certain bulbs and strip controllers only accept RGB values. I don't have any of these devices (yet...) but I can't imagine this would be difficult to implement.
- _[Clean]_ Comment, clean, and make code more efficient. 
###### As I'm not a professional programmer, I appreciate any input you have on this. If you have any questions, comments, etc... let me know.
